### PR TITLE
Update Stripe checkout docs

### DIFF
--- a/docs/stripe/8_stripe_checkout.md
+++ b/docs/stripe/8_stripe_checkout.md
@@ -29,7 +29,9 @@ class SubscriptionsController < ApplicationController
       }],
       subscription_data: {
         trial_period_days: 15,
-        pay_name: "base" # Optional. Overrides the Pay::Subscription name attribute
+        metadata: {
+          pay_name: "base" # Optional. Overrides the Pay::Subscription name attribute
+        }
       },
       success_url: root_url,
       cancel_url: root_url


### PR DESCRIPTION
`pay_name` override should be inside metadata. See https://github.com/pay-rails/pay/issues/562#issuecomment-1064142965